### PR TITLE
[GST-1327] Adds aws cluster discovery to Kafka

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,10 @@ kafka:
   auto_create_topics: "false"
   conf_dir: /home/kafka/etc
   data_dir: /home/kafka/data
+  default_replication_factor: 1
   group: kafka
   heap_opts: "-Xmx{{ (ansible_memtotal_mb / 2) | int }}m -Xms{{ (ansible_memtotal_mb / 2) | int }}m"
+  id: 1
   log_cleanup_interval_mins: 1
   log_dir: /home/kafka/log
   log_flush_interval_messages: 10000
@@ -32,3 +34,14 @@ kafka:
   zookeeper_connection_timeout_ms: 1000000
   zookeeper_hosts:
     - localhost
+
+  # If enabled AWS will be used to figure out which host and id should be used
+  # Note that you must install the AWS CLI tools on the machine to use this feature
+  aws_cluster_autodiscover:
+    enabled: false
+    hosts: []
+    # Tag to store the ID/index of the host that gets assigned to a machine
+    id_tag_name: KafkaID
+    # AWS CLI lookup filter
+    lookup_filter: "Name=tag:Environment,Values=dev Name=tag:Role,Values=kafka"
+    r53_zone_id: ~

--- a/files/aws_cluster_autodiscover
+++ b/files/aws_cluster_autodiscover
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -o nounset
+
+# Gaffa tape script that uses AWS tags to pick an available ID/Index from a list of hostnames
+# This ID can be used to assign then pick the hostname and machine ID for services that require such a setting
+# such as Kafka or Zookeeper.
+#
+# NOTE In the future we should replace this with Consul.
+#
+# Usage:
+# aws_cluster_autodiscover [Max number of machines in cluster] [AWS hostedzone ID] "[AWS ec2 describe-instances filter]" [Name of tag used to store id]
+# eg.
+# ./bin/aws_cluster_autodiscover "01.zookeeper.app.internal,02.zookeeper.app.internal,03.zookeeper.app.internal" "Z8LHX0FIHPY9F" "Name=tag:Environment,Values=dev Name=tag:Role,Values=zookeeper" "ZookeeperID"
+#
+# Returns:
+# Json array detaling the claimed ID and hostname
+# eg.
+# {"id": "1", "id_index0": "0", "hostname": "01.zookeeper.app.internal", "info": "Machine had no ID, claimed ID and R53 entry" }
+
+function die {
+	echo -e "\033[1;31mError: $1\033[0m"
+	exit 1
+}
+
+function output {
+	local -i CLAIMED_ID=$1
+	local CLAIMED_HOST=$2
+	local INFO=$3
+	local -i CLAIMED_ID_INDEX0=$((CLAIMED_ID - 1 ))
+	echo "{\"id\": \"${CLAIMED_ID}\", \"id_index0\": \"${CLAIMED_ID_INDEX0}\", \"hostname\": \"${CLAIMED_HOST}\", \"info\": \"${INFO}\" }"
+	exit 0
+}
+
+function main {
+	# Arguments
+	if [ "$#" -ne 4 ]; then
+		die "This script takes 4 parameters, only $# given"
+	fi
+	local HOSTS=(${1//,/ })
+	local HOSTED_ZONE_ID=$2
+	local LOOKUP_FILTER=$3
+	local ID_TAG_NAME=$4
+
+	# Initialise vars before usage since local always returns 0
+	local MAX_HOSTS=${#HOSTS[@]}
+	local CLAIMED_ID=""
+	local CLAIMED_HOST=""
+	local INSTANCE_ID=""
+	local INSTANCE_IP=""
+	local INSTANCE_REGION=""
+	local AVAILABLE_IDS=( )
+	local CLAIMED_IDS=( )
+	local UNCLAIMED_IDS=( )
+
+	INSTANCE_ID=$( curl -f -s http://169.254.169.254/latest/meta-data/instance-id/ )
+	INSTANCE_IP=$( curl -f -s http://169.254.169.254/latest/meta-data/local-ipv4/ )
+	INSTANCE_REGION=$( curl -f -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed -e '$s/.$//' )
+	if [[ -z ${INSTANCE_ID} || -z ${INSTANCE_IP} || -z ${INSTANCE_REGION} ]]; then
+		die "Could not grab instance ID or IP, are you running outside of EC2?"
+	fi
+
+	# Check to see if this machine has an ID tag already
+	CLAIMED_ID=$( aws ec2 describe-tags \
+		--region ${INSTANCE_REGION} \
+		--filter "Name=resource-id,Values=${INSTANCE_ID}" \
+		--output text "Name=key,Values=${ID_TAG_NAME}" \
+		--query "Tags[*].Value" )
+	if [[ -n ${CLAIMED_ID} ]]; then
+		output "${CLAIMED_ID}" "${HOSTS[$CLAIMED_ID - 1]}" "Machine already has an ID"
+	fi
+
+	# Figure out which ID and host to claim
+	AVAILABLE_IDS=( $(seq 1 "${MAX_HOSTS}") )
+	CLAIMED_IDS=( $( aws ec2 describe-instances \
+		--region ${INSTANCE_REGION} \
+		--filters ${LOOKUP_FILTER} Name=instance-state-name,Values=running \
+		--output text \
+		--query "Reservations[*].Instances[*].Tags[*] | [] | [] | [?Key=='${ID_TAG_NAME}'] | [*].Value" ) )
+	if [[ "${#CLAIMED_IDS[@]}" -gt 0 ]]; then
+		# Use comm to diff the ID arrays
+		UNCLAIMED_IDS=( $( comm -13 \
+			<(for X in "${CLAIMED_IDS[@]}"; do echo "${X}"; done | sort) \
+			<(for X in "${AVAILABLE_IDS[@]}"; do echo "${X}"; done | sort) ) )
+
+		if [ ${#UNCLAIMED_IDS[@]} -eq 0 ]; then
+			# No free IDs, throw an error
+			die "No free IDs found, aborting"
+		fi
+
+		# Claim the first free ID
+		CLAIMED_ID="${UNCLAIMED_IDS[0]}"
+	else
+		# No IDs have been claimed, grab the first one
+		CLAIMED_ID="1"
+	fi
+
+	CLAIMED_HOST="${HOSTS[$CLAIMED_ID - 1]}"
+
+	# Claim the hostname
+	aws route53 change-resource-record-sets \
+		--region ${INSTANCE_REGION} \
+		--hosted-zone-id ${HOSTED_ZONE_ID} \
+		--change-batch "{ \"Changes\": [ { \"Action\": \"UPSERT\", \"ResourceRecordSet\": { \"Name\": \"${CLAIMED_HOST}\", \"Type\": \"A\", \"TTL\": 300, \"ResourceRecords\": [ { \"Value\": \"${INSTANCE_IP}\" } ] } } ] }" \
+		> /dev/null 2>&1 \
+		|| die "Failed to update R53 entry for ${CLAIMED_HOST}"
+
+	# Claim the ID
+	aws ec2 create-tags \
+		--region ${INSTANCE_REGION} \
+		--resources ${INSTANCE_ID} \
+		--tags Key=${ID_TAG_NAME},Value=${CLAIMED_ID} \
+		> /dev/null 2>&1 \
+		|| die "Failed to update Tag entry for with ID ${CLAIMED_ID}"
+
+	output "${CLAIMED_ID}" "${CLAIMED_HOST}" "Machine had no ID, claimed ID and R53 entry"
+}
+
+main "$@"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -12,6 +12,7 @@
     state: directory
     path: "{{ item }}"
   with_items:
+    - "/home/{{ kafka.user }}/bin"
     - "/home/{{ kafka.user }}/tmp"
     - "/home/{{ kafka.user }}/log"
     - "/home/{{ kafka.user }}/data"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,6 +9,33 @@
   notify:
     - restart kafka
 
+- name: Copy AWS autodiscover script
+  become: yes
+  become_user: "{{ kafka.user }}"
+  copy:
+    src: aws_cluster_autodiscover
+    dest: "/home/{{ kafka.user }}/bin/aws_cluster_autodiscover"
+    owner: "{{ kafka.user }}"
+    group: "{{ kafka.group }}"
+    mode: 0750
+  when: kafka.aws_cluster_autodiscover.enabled
+
+- name: Run AWS autodiscover script and grab cluster settings
+  become: yes
+  become_user: "{{ kafka.user }}"
+  command: "./aws_cluster_autodiscover {{ kafka.aws_cluster_autodiscover.hosts | join(',') }} {{ kafka.aws_cluster_autodiscover.r53_zone_id }} \"{{ kafka.aws_cluster_autodiscover.lookup_filter }}\" {{ kafka.aws_cluster_autodiscover.id_tag_name}}"
+  args:
+    chdir: "/home/{{ kafka.user }}/bin"
+  register: aws_cluster_autodiscover
+  when: kafka.aws_cluster_autodiscover.enabled
+
+- name: Set cluster facts based on AWS autodiscover script output
+  set_fact:
+    kafka:
+      aws_cluster_autodiscover:
+        data: "{{ aws_cluster_autodiscover.stdout | from_json }}"
+  when: kafka.aws_cluster_autodiscover.enabled
+
 - name: Overwrite the start script so the Java Opts can be changed if Kafka 0.8.1.1
   become: yes
   lineinfile:
@@ -74,9 +101,12 @@
     name: kafka
     state: started
     enabled: yes
+    
+- name: Flush handlers to ensure Kafka is up to date
+  meta: flush_handlers
 
 - name: Wait for Kafka port
   wait_for:
     port: "{{ kafka.port }}"
     state: started
-    timeout: 30
+    timeout: 120

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -5,8 +5,10 @@
 
 # The id of the broker. This must be set to a unique integer for each broker.
 # If left off one is auto-assigned
-{% if kafka.broker_id is defined %}
-broker.id={{ kafka.broker_id }}
+{% if kafka.aws_cluster_autodiscover.data is defined %}
+broker.id={{ kafka.aws_cluster_autodiscover.data.id }}
+{% else %}
+broker.id={{ kafka.id }}
 {% endif %}
 
 ############################# Socket Server Settings #############################
@@ -16,6 +18,12 @@ port={{ kafka.port }}
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
 {% if kafka.listen_address is defined %}
 host.name={{ kafka.listen_address }}
+{% endif %}
+
+{% if kafka.aws_cluster_autodiscover.data is defined %}
+advertised.host.name={{ kafka.aws_cluster_autodiscover.data.hostname }}
+{% elif kafka.advertised_host_name is defined %}
+advertised.host.name={{ kafka.advertised_host_name }}
 {% endif %}
 
 {# The number of threads handling network requests #}
@@ -43,6 +51,9 @@ auto.create.topics.enable={{ kafka.auto_create_topics }}
 # The number of logical partitions per topic per server. More partitions allow greater parallelism
 # for consumption, but also mean more files.
 num.partitions={{ kafka.num_partitions }}
+
+# Set the default replication factor, set to this to the number of kafka brokers in your cluster
+default.replication.factor={{ kafka.default_replication_factor }}
 
 ############################# Log Flush Policy #############################
 


### PR DESCRIPTION
This allows kafka machines to discover which id and hostname they
should use in AWS, this will allow machines to be replaced if they die
without disruption/manual intervention. Rolling AMI updates are also
possible.

Also added id and advertised hostname settings so a machine can be
recognised properly in a cluster, Kafka will auto rebalance data if these
settings are consistent, so if a machine dies or is replace it will
automatically sync data from the rest of the cluster if the hostname
and id are recognised.