### PR TITLE
[GITHUB-15] Fixes download mirror

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 kafka:
-  apache_mirror: http://apache.mirror.anlx.net/
+  apache_mirror: https://archive.apache.org/dist/
   auto_create_topics: "false"
   conf_dir: /home/kafka/etc
   controlled_shutdown_enable: true

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
+allow_world_readable_tmpfiles = True
 hash_behaviour = merge
 roles_folder = roles

--- a/tests/local_requirements.yml
+++ b/tests/local_requirements.yml
@@ -1,6 +1,5 @@
 ---
 
 - src: sansible.zookeeper
-  version: v1.0
 
 - src: sansible.users_and_groups


### PR DESCRIPTION
Seems like apache.mirror.anlx.net hasi been replaced with
archive.apache.org, this updates the mirror var in defaults.