### PR TITLE
[GITHUB-26] Fixes status in Sys V init

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -58,11 +58,3 @@
     owner: root
     mode: 0755
     src: kafka_sysv.j2
-  notify:
-    - restart kafka
-
-- name: Ensure Kafka runs on boot
-  become: yes
-  service:
-    enabled: yes
-    name: kafka

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -146,6 +146,7 @@
 - name: Ensure Kafka is running
   become: yes
   service:
+    enabled: yes
     name: kafka
     state: started
 

--- a/templates/kafka_sysv.j2
+++ b/templates/kafka_sysv.j2
@@ -1,7 +1,8 @@
+#!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          kafka
-# Required-Start:    zookeeper
-# Required-Stop:     zookeeper
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: start kafka
@@ -23,66 +24,96 @@ SCRIPTNAME=/etc/init.d/$NAME
 
 . /lib/lsb/init-functions
 if [ -f /etc/default/rcS ]; then
-  . /etc/default/rcS
+    . /etc/default/rcS
 fi
 
 do_start()
 {
-  if [ -n "$MAX_OPEN_FILES" ]; then
-    ulimit -n $MAX_OPEN_FILES
-  fi
-  KAFKA_HEAP_OPTS="${KAFKA_HEAP_OPTS}" JMX_PORT="${JMX_PORT}" \
-      exec start-stop-daemon --chuid ${USER}:${GROUP}  --start --quiet \
-      --background --pidfile $PIDFILE --exec $DAEMON -- \
-    $DAEMON_ARGS \
-    || return 2
+    if [ -f $PIDFILE ]; then
+      return 0
+    fi
+
+    if [ -e ${PIDFILE} ]; then
+        # Check the actual status of process
+        status_of_proc -p $PIDFILE java "$NAME" && status="0" || status="$?"
+        # If the status is successfull, no need to start again.
+        [ ${status} = "0" ] && exit 0
+    fi
+
+    if [ -n "$MAX_OPEN_FILES" ]; then
+        ulimit -n $MAX_OPEN_FILES
+    fi
+
+    KAFKA_HEAP_OPTS="${KAFKA_HEAP_OPTS}" JMX_PORT="${JMX_PORT}" \
+        exec start-stop-daemon --start --quiet \
+            --chuid ${USER}:${GROUP}  \
+            --background \
+            --pidfile $PIDFILE \
+            --make-pidfile \
+            --exec $DAEMON -- \
+            $DAEMON_ARGS \
+        || return 2
 }
 
 
 do_stop () {
-    exec start-stop-daemon --chuid ${USER}:${GROUP} --start  \
-        --pidfile $PIDFILE \
-        --exec /home/{{ sansible_kafka_user }}/kafka/bin/kafka-server-stop.sh
+    if [ -e ${PIDFILE} ]; then
+        status_of_proc -p $PIDFILE java "$NAME" && status="0" || status="$?"
+        if [ "$status" = "0" ]; then
+            start-stop-daemon --chuid ${USER}:${GROUP} --start  --quiet \
+                --pidfile $PIDFILE \
+                --exec /home/{{ sansible_kafka_user }}/kafka/bin/kafka-server-stop.sh
+            RETVAL="$?"
+            [ "$RETVAL" = 2 ] && return 2
+
+            # Many daemons don't delete their pidfiles when they exit.
+            [ "$RETVAL" = 0 ] && rm -f $PIDFILE
+
+            return "$RETVAL"
+        fi
+    fi
+    return 0
 }
 
 case "$1" in
-  start)
-    if [ "$VERBOSE" != no ]; then
-      log_begin_msg "Starting $NAME..."
-    fi
-    do_start
-    if [ "$VERBOSE" != no ]; then
-      log_end_msg 0
-    fi
-  ;;
+    start)
+        if [ "$VERBOSE" != no ]; then
+            log_begin_msg "Starting $NAME..."
+        fi
+        do_start
+        if [ "$VERBOSE" != no ]; then
+            log_end_msg 0
+        fi
+        ;;
 
-  restart)
-    if [ "$VERBOSE" != no ]; then
-      log_begin_msg "Restarting $NAME..."
-    fi
-    do_stop
-    do_start
-    if [ "$VERBOSE" != no ]; then
-      log_end_msg 0
-    fi  ;;
+    restart)
+        if [ "$VERBOSE" != no ]; then
+            log_begin_msg "Restarting $NAME..."
+        fi
+        do_stop
+        do_start
+        if [ "$VERBOSE" != no ]; then
+            log_end_msg 0
+        fi  ;;
 
-  stop)
-    if [ "$VERBOSE" != no ]; then
-      log_begin_msg "Stopping $NAME..."
-    fi
-    do_stop
-    if [ "$VERBOSE" != no ]; then
-      log_end_msg 0
-    fi
-  ;;
+    stop)
+        if [ "$VERBOSE" != no ]; then
+            log_begin_msg "Stopping $NAME..."
+        fi
+        do_stop
+        if [ "$VERBOSE" != no ]; then
+            log_end_msg 0
+        fi
+        ;;
 
-  status)
-    status_of_proc java $NAME
-  ;;
-  *)
-    log_success_msg "Usage: $SCRIPTNAME {start|stop|status|restart}"
-    exit 1
-    ;;
+    status)
+        status_of_proc -p $PIDFILE java "$NAME" && status="0" || status="$?"
+        ;;
+
+    *)
+        log_success_msg "Usage: $SCRIPTNAME {start|stop|status|restart}"
+        exit 1
+        ;;
 esac
 
 exit 0


### PR DESCRIPTION
Fixes the status of proc calls so they specifically target the
Kafka process, also switched to four spaces instead of 2.

Moved Kafka service enablement to the configure step to ensure
that the service only starts once configued.